### PR TITLE
feat: Add --dry-run flag to CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,22 @@ async function main() {
   try {
     // コマンドライン引数を取得
     const args = process.argv.slice(2);
-    let inputText = args.join(' ');
+
+    // --dry-run フラグをチェック
+    let dryRun = false;
+    const filteredArgs = args.filter(arg => {
+      if (arg === '--dry-run' || arg === '-d') {
+        dryRun = true;
+        return false;
+      }
+      return true;
+    });
+
+    let inputText = filteredArgs.join(' ');
+
+    if (dryRun) {
+      console.log('🧪 ドライランモード: LLMによる生成をスキップします\n');
+    }
 
     // 引数がない場合は対話モード
     if (!inputText) {
@@ -78,10 +93,18 @@ async function main() {
     }
 
     // アジェンダ生成
-    console.log('🤖 アジェンダを生成中...');
-    const result = await agent.generateAgendaWithParams(targetMember, parsed.period);
+    if (dryRun) {
+      console.log('📋 データを取得中...');
+    } else {
+      console.log('🤖 アジェンダを生成中...');
+    }
+    const result = await agent.generateAgendaWithParams(targetMember, parsed.period, { dryRun });
 
-    console.log('✅ アジェンダ生成完了！\n');
+    if (dryRun) {
+      console.log('✅ データ取得完了！\n');
+    } else {
+      console.log('✅ アジェンダ生成完了！\n');
+    }
 
     // メタデータ表示
     console.log('--- 生成情報 ---');


### PR DESCRIPTION
## 概要

通常のCLI（`npm run agenda`）に`--dry-run`フラグを追加しました。
LLMを呼び出さずに、Backlogから取得したデータのプレビューを表示できます。

## 変更内容

### CLI強化 (src/cli.ts)
- `--dry-run` / `-d` フラグをサポート
- フラグの位置に関わらず動作
- ドライランモード実行時にメッセージ表示

### 既存機能の活用
- Agent の `generateAgendaWithParams` の既存 `dryRun` オプションを活用
- バッチCLI は既に `--dry-run` をサポート済み
- テストも既に存在

## 使用例

### 基本的なドライラン
```bash
npm run agenda "佐藤さんの直近2週間" --dry-run
```

### 対話モードでのドライラン
```bash
npm run agenda --dry-run
```

### 出力例
```
🧪 ドライランモード: LLMによる生成をスキップします

🚀 1on1アジェンダ生成を開始します...
入力: 佐藤さんの直近2週間 

📝 パラメータを抽出中...
  メンバー名: 佐藤
  期間: {"weeks":2}

🔍 メンバーを検索中...
✅ メンバーを特定しました: 佐藤太郎 (sato@example.com)

📋 データを取得中...
✅ データ取得完了！

--- 生成情報 ---
メンバー: 佐藤太郎
期間: 2025-12-12 〜 2025-12-26
課題数: 5件

--- プレビュー ---
# [Dry Run] Data Preview: 佐藤太郎

**Period**: 2025-12-12 - 2025-12-26

## Issues (5)
- [処理中] PROJ-123: ○○機能の実装 (https://...)
- [完了] PROJ-124: △△のバグ修正 (https://...)
...
```

## ユースケース

1. **本番実行前の確認**
   - データが正しく取得できるか確認
   - 対象メンバーが正しいか確認
   - AWS Bedrockの料金を発生させずに確認

2. **デバッグ・トラブルシューティング**
   - Backlog接続の確認
   - ユーザー検索の確認
   - データ取得の確認

3. **ドキュメント・デモ用**
   - 実際のLLM呼び出しなしでフロー確認

## テスト結果
- ✅ 全63テスト通過
- ✅ ビルドエラーなし
- ✅ 既存のドライランテスト有効

## 統計
- 変更行数: +27 / -4
- 変更ファイル: 1ファイル (src/cli.ts)
- コミット数: 1

## 関連PR
- PR #8: 元のドライランモード実装（Bedrock統合前）
- PR #10: テンプレート外部化を含むドライランモード

🤖 Generated with [Claude Code](https://claude.com/claude-code)