### PR TITLE
feat: Add Slack and Google Calendar integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,10 @@ BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-5-20250929-v1:0
 
 # Slack Integration (Optional)
 # SLACK_BOT_TOKEN=xoxb-your-bot-token
-# SLACK_USER_TOKEN=xoxp-your-user-token
+
+# Google Calendar Integration (Optional)
+# GOOGLE_CALENDAR_CREDENTIALS_PATH=./credentials.json
+# GOOGLE_CALENDAR_TOKEN_PATH=./token.json
 
 # Options
 # MAX_CONCURRENCY=5

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ dist/
 .env.local
 .env.*.local
 
+# Google Calendar OAuth2 tokens
+token.json
+credentials.json
+
 # Test coverage
 coverage/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@slack/web-api": "^7.12.0",
         "dotenv": "^17.2.3",
+        "googleapis": "^169.0.0",
         "js-yaml": "^4.1.1",
         "prompts": "^2.4.2",
         "zod": "^4.1.12"
@@ -1162,6 +1163,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1208,6 +1226,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2381,6 +2409,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -2412,6 +2449,30 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/argparse": {
@@ -2447,6 +2508,41 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -2472,6 +2568,21 @@
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
       "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2547,6 +2658,24 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2626,6 +2755,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2697,10 +2835,31 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2923,6 +3082,12 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2963,6 +3128,29 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -3000,6 +3188,22 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -3035,6 +3239,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -3079,6 +3295,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3116,6 +3361,82 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "169.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-169.0.0.tgz",
+      "integrity": "sha512-IOGMG8tljCZSLvYgdojRu6mB10KEsK0J7X62sXXlQz9koe5BUAW+rqkY3qhQM9wXM6hVL3/Hase7XbxoMyeYiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.2.0",
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.1.tgz",
+      "integrity": "sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.1.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3126,6 +3447,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/has-symbols": {
@@ -3192,6 +3526,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -3225,6 +3572,15 @@
       "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
       "license": "MIT"
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -3249,6 +3605,21 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3261,11 +3632,41 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/kleur": {
       "version": "3.0.3",
@@ -3282,6 +3683,12 @@
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -3344,6 +3751,30 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3376,6 +3807,44 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/object-assign": {
@@ -3476,6 +3945,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3492,6 +3967,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -3669,6 +4160,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {
@@ -3898,6 +4404,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -3936,6 +4454,102 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strnum": {
       "version": "2.1.2",
@@ -4050,6 +4664,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -4210,6 +4830,15 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4237,6 +4866,97 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@modelcontextprotocol/sdk": "^1.0.4",
     "@slack/web-api": "^7.12.0",
     "dotenv": "^17.2.3",
+    "googleapis": "^169.0.0",
     "js-yaml": "^4.1.1",
     "prompts": "^2.4.2",
     "zod": "^4.1.12"

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -5,6 +5,9 @@ import type { AgendaInput, AgendaOutput } from './model/agenda.js';
 import { PERIOD_DEFAULTS, TIME } from './constants.js';
 
 import { SlackClient } from './slack/client.js';
+import type { SlackMessage } from './model/slack.js';
+import { CalendarClient } from './calendar/client.js';
+import type { CalendarEvent, MeetingStats } from './model/calendar.js';
 
 /**
  * 1on1アジェンダ生成エージェント
@@ -13,6 +16,7 @@ import { SlackClient } from './slack/client.js';
 export class OneOnOneAgendaAgent {
   private backlogClient: BacklogClient;
   private slackClient: SlackClient;
+  private calendarClient: CalendarClient;
   private parameterParser: ParameterParser;
   private agendaGenerator: AgendaGenerator;
 
@@ -20,12 +24,14 @@ export class OneOnOneAgendaAgent {
     backlogClient?: BacklogClient,
     parameterParser?: ParameterParser,
     agendaGenerator?: AgendaGenerator,
-    slackClient?: SlackClient
+    slackClient?: SlackClient,
+    calendarClient?: CalendarClient
   ) {
     this.backlogClient = backlogClient || new BacklogClient();
     this.parameterParser = parameterParser || new ParameterParser();
     this.agendaGenerator = agendaGenerator || new AgendaGenerator();
     this.slackClient = slackClient || new SlackClient();
+    this.calendarClient = calendarClient || new CalendarClient();
   }
 
   /**
@@ -106,15 +112,37 @@ export class OneOnOneAgendaAgent {
     );
 
     // Slackメッセージ取得
-    let slackMessages: any[] = [];
+    let slackMessages: SlackMessage[] = [];
     if (this.slackClient.isAvailable() && member.mailAddress) {
-      const slackUserId = await this.slackClient.findUserByEmail(member.mailAddress);
-      if (slackUserId) {
-        slackMessages = await this.slackClient.getMessagesInPeriod(
-          slackUserId,
+      try {
+        await this.slackClient.connect();
+        const slackUser = await this.slackClient.findUserByEmail(member.mailAddress);
+        if (slackUser) {
+          slackMessages = await this.slackClient.getMessagesInPeriod(
+            slackUser.id,
+            period.start,
+            period.end
+          );
+        }
+      } catch (error) {
+        console.warn(`Slackデータ取得に失敗: ${error}`);
+      }
+    }
+
+    // Calendarイベント取得
+    let calendarEvents: CalendarEvent[] = [];
+    let calendarStats: MeetingStats | undefined;
+    if (this.calendarClient.isAvailable() && member.mailAddress) {
+      try {
+        await this.calendarClient.connect();
+        calendarEvents = await this.calendarClient.getEventsInPeriod(
+          member.mailAddress,
           period.start,
           period.end
         );
+        calendarStats = await this.calendarClient.getMeetingStats(calendarEvents);
+      } catch (error) {
+        console.warn(`Calendarデータ取得に失敗: ${error}`);
       }
     }
 
@@ -132,9 +160,13 @@ export class OneOnOneAgendaAgent {
         issues,
         pullRequests,
       },
-      slack: {
+      slack: slackMessages.length > 0 ? {
         messages: slackMessages,
-      },
+      } : undefined,
+      calendar: calendarEvents.length > 0 && calendarStats ? {
+        events: calendarEvents,
+        stats: calendarStats,
+      } : undefined,
     };
 
     let markdown: string;
@@ -197,6 +229,33 @@ export class OneOnOneAgendaAgent {
       output += `\n`;
     }
 
+    if (input.calendar) {
+      output += `## Calendar Events (${input.calendar.events.length})\n`;
+      if (input.calendar.events.length === 0) {
+        output += `- No events found.\n`;
+      } else {
+        for (const event of input.calendar.events) {
+          const startDate = new Date(event.start).toLocaleString('ja-JP');
+          output += `- [${startDate}] [${event.eventType}] ${event.summary} (${event.durationMinutes}分)\n`;
+        }
+      }
+      output += `\n`;
+
+      if (input.calendar.stats) {
+        output += `## Meeting Statistics\n`;
+        output += `- Total Events: ${input.calendar.stats.totalEvents}\n`;
+        output += `- Total Meeting Time: ${input.calendar.stats.totalMeetingMinutes}分\n`;
+        output += `- Meeting Count: ${input.calendar.stats.meetingCount}\n`;
+        output += `- 1on1 Count: ${input.calendar.stats.oneOnOneCount}\n`;
+        output += `- Focus Time: ${input.calendar.stats.focusTimeMinutes}分\n`;
+        output += `- Average Meeting Duration: ${input.calendar.stats.averageMeetingDuration}分\n`;
+        if (input.calendar.stats.busiestDay) {
+          output += `- Busiest Day: ${input.calendar.stats.busiestDay}\n`;
+        }
+        output += `\n`;
+      }
+    }
+
     return output;
   }
 
@@ -205,6 +264,8 @@ export class OneOnOneAgendaAgent {
    */
   async cleanup(): Promise<void> {
     await this.backlogClient.disconnect();
+    await this.slackClient.disconnect();
+    await this.calendarClient.disconnect();
   }
 
   /**

--- a/src/calendar/client.ts
+++ b/src/calendar/client.ts
@@ -1,0 +1,194 @@
+import { google } from 'googleapis';
+import type { calendar_v3 } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
+import { readFile, writeFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { getConfig } from '../config.js';
+import type { CalendarEvent, MeetingStats } from '../model/calendar.js';
+import { convertToCalendarEvent, calculateMeetingStats } from './helpers.js';
+
+/**
+ * Google Calendarクライアント
+ * Google Calendar APIを使用してイベント情報を取得する
+ */
+export class CalendarClient {
+  private auth: OAuth2Client | null = null;
+  private calendar: calendar_v3.Calendar | null = null;
+  private connected: boolean = false;
+
+  /**
+   * Calendar連携が利用可能かどうかを判定
+   * @returns 認証情報が設定されている場合はtrue
+   */
+  isAvailable(): boolean {
+    const config = getConfig();
+    return !!(config.calendar && config.calendar.credentialsPath);
+  }
+
+  /**
+   * Google Calendar APIに接続する
+   * @throws Error 認証情報が設定されていない場合
+   */
+  async connect(): Promise<void> {
+    if (this.connected) {
+      return;
+    }
+
+    const config = getConfig();
+
+    if (!config.calendar.credentialsPath) {
+      throw new Error(
+        'GOOGLE_CALENDAR_CREDENTIALS_PATHが設定されていません。\n' +
+        '設定方法: .envファイルにGOOGLE_CALENDAR_CREDENTIALS_PATH=./credentials.jsonを追加してください。'
+      );
+    }
+
+    try {
+      // 認証情報ファイルを読み込む
+      const credentialsContent = await readFile(config.calendar.credentialsPath, 'utf-8');
+      const credentials = JSON.parse(credentialsContent);
+
+      const { client_secret, client_id, redirect_uris } = credentials.installed || credentials.web;
+
+      this.auth = new OAuth2Client(client_id, client_secret, redirect_uris[0]);
+
+      // トークンファイルが存在する場合は読み込む
+      const tokenPath = config.calendar.tokenPath || './token.json';
+      if (existsSync(tokenPath)) {
+        const tokenContent = await readFile(tokenPath, 'utf-8');
+        const token = JSON.parse(tokenContent);
+        this.auth.setCredentials(token);
+      } else {
+        // トークンが存在しない場合は認証が必要
+        throw new Error(
+          'Google Calendar のトークンファイルが見つかりません。\n' +
+          '初回認証が必要です。詳細はREADMEを参照してください。\n' +
+          `トークンパス: ${tokenPath}`
+        );
+      }
+
+      this.calendar = google.calendar({ version: 'v3', auth: this.auth });
+      this.connected = true;
+
+      console.log('Google Calendar APIに接続しました');
+    } catch (error) {
+      throw new Error(`Google Calendar接続エラー: ${error}`);
+    }
+  }
+
+  /**
+   * 接続を切断する
+   */
+  async disconnect(): Promise<void> {
+    this.auth = null;
+    this.calendar = null;
+    this.connected = false;
+  }
+
+  /**
+   * 指定期間内のイベントを取得
+   * @param _userEmail ユーザーのメールアドレス（現在は未使用、将来的に複数カレンダーサポート用）
+   * @param start 開始日時
+   * @param end 終了日時
+   * @returns イベント配列
+   */
+  async getEventsInPeriod(
+    _userEmail: string,
+    start: Date,
+    end: Date
+  ): Promise<CalendarEvent[]> {
+    if (!this.calendar) {
+      throw new Error('Google Calendar APIに接続されていません。connect()を先に呼び出してください。');
+    }
+
+    const events: CalendarEvent[] = [];
+    let pageToken: string | undefined;
+
+    try {
+      do {
+        const response = await this.calendar.events.list({
+          calendarId: 'primary',
+          timeMin: start.toISOString(),
+          timeMax: end.toISOString(),
+          maxResults: 250,
+          singleEvents: true,
+          orderBy: 'startTime',
+          pageToken,
+        });
+
+        const items = response.data.items || [];
+
+        for (const rawEvent of items) {
+          // rawEventの型はcalendar_v3.Schema$Event
+          // idがnullableなので、存在チェックを行う
+          if (!rawEvent.id) {
+            continue;
+          }
+
+          const event = convertToCalendarEvent(rawEvent as any);
+          if (event) {
+            events.push(event);
+          }
+        }
+
+        pageToken = response.data.nextPageToken || undefined;
+      } while (pageToken);
+
+      return events;
+    } catch (error) {
+      console.error(`Calendarイベント取得エラー: ${error}`);
+      return [];
+    }
+  }
+
+  /**
+   * イベント一覧から会議統計を計算する
+   * @param events イベント配列
+   * @returns 会議統計
+   */
+  async getMeetingStats(events: CalendarEvent[]): Promise<MeetingStats> {
+    return calculateMeetingStats(events);
+  }
+
+  /**
+   * OAuth2認証フローを実行してトークンを取得する
+   * （初回認証時に使用）
+   * @param code 認証コード
+   */
+  async getTokenFromCode(code: string): Promise<void> {
+    if (!this.auth) {
+      throw new Error('OAuth2Clientが初期化されていません。');
+    }
+
+    const config = getConfig();
+    const tokenPath = config.calendar.tokenPath || './token.json';
+
+    try {
+      const { tokens } = await this.auth.getToken(code);
+      this.auth.setCredentials(tokens);
+
+      // トークンをファイルに保存
+      await writeFile(tokenPath, JSON.stringify(tokens, null, 2));
+      console.log(`トークンを保存しました: ${tokenPath}`);
+    } catch (error) {
+      throw new Error(`トークン取得エラー: ${error}`);
+    }
+  }
+
+  /**
+   * 認証URLを生成する
+   * （初回認証時に使用）
+   */
+  generateAuthUrl(): string {
+    if (!this.auth) {
+      throw new Error('OAuth2Clientが初期化されていません。');
+    }
+
+    const authUrl = this.auth.generateAuthUrl({
+      access_type: 'offline',
+      scope: ['https://www.googleapis.com/auth/calendar.readonly'],
+    });
+
+    return authUrl;
+  }
+}

--- a/src/calendar/helpers.ts
+++ b/src/calendar/helpers.ts
@@ -1,0 +1,175 @@
+import type { CalendarEvent, EventType, MeetingStats } from '../model/calendar.js';
+
+/**
+ * イベント種別を判定する
+ */
+export function determineEventType(
+  summary: string,
+  attendees?: Array<{ email: string }>
+): EventType {
+  const lowerSummary = summary.toLowerCase();
+
+  // 1on1の判定
+  if (
+    lowerSummary.includes('1on1') ||
+    lowerSummary.includes('1-on-1') ||
+    lowerSummary.includes('one on one') ||
+    lowerSummary.includes('one-on-one') ||
+    (attendees && attendees.length === 2) // 2人のみの会議
+  ) {
+    return 'one-on-one';
+  }
+
+  // 集中時間の判定
+  if (
+    lowerSummary.includes('focus') ||
+    lowerSummary.includes('集中') ||
+    lowerSummary.includes('作業') ||
+    lowerSummary.includes('do not disturb') ||
+    (!attendees || attendees.length === 0) // 参加者がいない
+  ) {
+    return 'focus-time';
+  }
+
+  // その他の会議
+  if (attendees && attendees.length > 0) {
+    return 'meeting';
+  }
+
+  return 'other';
+}
+
+/**
+ * イベントの所要時間を計算する（分単位）
+ */
+export function calculateDuration(start: string, end: string): number {
+  const startTime = new Date(start).getTime();
+  const endTime = new Date(end).getTime();
+  return Math.round((endTime - startTime) / (1000 * 60)); // ミリ秒を分に変換
+}
+
+/**
+ * イベント一覧から会議統計を計算する
+ */
+export function calculateMeetingStats(events: CalendarEvent[]): MeetingStats {
+  let totalEvents = 0;
+  let totalMeetingMinutes = 0;
+  let meetingCount = 0;
+  let oneOnOneCount = 0;
+  let focusTimeMinutes = 0;
+
+  // 日ごとの会議時間を記録（最も忙しい日を特定するため）
+  const dailyMinutes = new Map<string, number>();
+
+  for (const event of events) {
+    totalEvents++;
+    totalMeetingMinutes += event.durationMinutes;
+
+    // イベント種類ごとのカウント
+    switch (event.eventType) {
+      case 'meeting':
+        meetingCount++;
+        break;
+      case 'one-on-one':
+        oneOnOneCount++;
+        meetingCount++; // 1on1も会議数にカウント
+        break;
+      case 'focus-time':
+        focusTimeMinutes += event.durationMinutes;
+        break;
+    }
+
+    // 日ごとの会議時間を集計
+    const eventDate = event.start.split('T')[0]; // YYYY-MM-DD
+    const currentMinutes = dailyMinutes.get(eventDate) || 0;
+    dailyMinutes.set(eventDate, currentMinutes + event.durationMinutes);
+  }
+
+  // 平均会議時間を計算
+  const averageMeetingDuration = meetingCount > 0
+    ? Math.round(totalMeetingMinutes / meetingCount)
+    : 0;
+
+  // 最も忙しい日を特定
+  let busiestDay: string | undefined;
+  let maxMinutes = 0;
+  for (const [date, minutes] of dailyMinutes.entries()) {
+    if (minutes > maxMinutes) {
+      maxMinutes = minutes;
+      busiestDay = date;
+    }
+  }
+
+  return {
+    totalEvents,
+    totalMeetingMinutes,
+    meetingCount,
+    oneOnOneCount,
+    focusTimeMinutes,
+    averageMeetingDuration,
+    busiestDay,
+  };
+}
+
+/**
+ * Google Calendar APIのイベントをCalendarEventに変換する
+ */
+export function convertToCalendarEvent(
+  rawEvent: {
+    id: string;
+    summary?: string;
+    description?: string;
+    status?: string;
+    htmlLink?: string;
+    start?: {
+      dateTime?: string;
+      date?: string;
+    };
+    end?: {
+      dateTime?: string;
+      date?: string;
+    };
+    attendees?: Array<{
+      email: string;
+      displayName?: string;
+      responseStatus?: string;
+    }>;
+    organizer?: {
+      email: string;
+    };
+  }
+): CalendarEvent | null {
+  // 開始・終了時刻がない場合はスキップ
+  if (!rawEvent.start || !rawEvent.end) {
+    return null;
+  }
+
+  const start = rawEvent.start.dateTime || rawEvent.start.date;
+  const end = rawEvent.end.dateTime || rawEvent.end.date;
+
+  if (!start || !end) {
+    return null;
+  }
+
+  const summary = rawEvent.summary || '(タイトルなし)';
+  const durationMinutes = calculateDuration(start, end);
+  const eventType = determineEventType(summary, rawEvent.attendees);
+
+  return {
+    id: rawEvent.id,
+    summary,
+    description: rawEvent.description,
+    start,
+    end,
+    durationMinutes,
+    attendees: rawEvent.attendees?.map((a) => ({
+      email: a.email,
+      displayName: a.displayName,
+      responseStatus: a.responseStatus || 'needsAction',
+    })),
+    organizer: rawEvent.organizer?.email,
+    status: rawEvent.status || 'confirmed',
+    eventType,
+    htmlLink: rawEvent.htmlLink,
+  };
+}

--- a/src/calendar/types.ts
+++ b/src/calendar/types.ts
@@ -1,0 +1,36 @@
+/**
+ * Google Calendar API レスポンス型定義
+ */
+
+/**
+ * calendar.events.list APIレスポンス
+ */
+export type CalendarEventsListResponse = {
+  items?: Array<{
+    id: string;
+    summary?: string;
+    description?: string;
+    status?: string;
+    htmlLink?: string;
+    start?: {
+      dateTime?: string;
+      date?: string;
+      timeZone?: string;
+    };
+    end?: {
+      dateTime?: string;
+      date?: string;
+      timeZone?: string;
+    };
+    attendees?: Array<{
+      email: string;
+      displayName?: string;
+      responseStatus?: string;
+    }>;
+    organizer?: {
+      email: string;
+      displayName?: string;
+    };
+  }>;
+  nextPageToken?: string;
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,10 @@ export interface AppConfig {
     botToken?: string;
     userToken?: string;
   };
+  calendar: {
+    credentialsPath?: string;
+    tokenPath?: string;
+  };
   options?: {
     maxConcurrency?: number;
     continueOnError?: boolean;
@@ -64,6 +68,10 @@ export function loadConfig(): AppConfig {
     slack: {
       botToken: process.env.SLACK_BOT_TOKEN,
       userToken: process.env.SLACK_USER_TOKEN,
+    },
+    calendar: {
+      credentialsPath: process.env.GOOGLE_CALENDAR_CREDENTIALS_PATH,
+      tokenPath: process.env.GOOGLE_CALENDAR_TOKEN_PATH,
     },
   };
 

--- a/src/model/agenda.ts
+++ b/src/model/agenda.ts
@@ -1,4 +1,5 @@
 import type { IssueSummary, PullRequestSummary } from './backlog.js';
+import type { CalendarEvent, MeetingStats } from './calendar.js';
 
 /**
  * アジェンダ生成のための入力データ
@@ -37,6 +38,13 @@ export type AgendaInput = {
       permalink?: string;
       type: string;
     }>;
+  };
+  /** Calendar情報 */
+  calendar?: {
+    /** イベント一覧 */
+    events: CalendarEvent[];
+    /** 会議統計 */
+    stats: MeetingStats;
   };
 };
 

--- a/src/model/calendar.ts
+++ b/src/model/calendar.ts
@@ -1,0 +1,68 @@
+/**
+ * イベント種別
+ */
+export type EventType =
+  | 'meeting'          // 会議
+  | 'one-on-one'       // 1on1
+  | 'focus-time'       // 集中時間
+  | 'other';           // その他
+
+/**
+ * イベント参加者
+ */
+export type EventAttendee = {
+  /** メールアドレス */
+  email: string;
+  /** 表示名 */
+  displayName?: string;
+  /** 参加応答ステータス */
+  responseStatus: string; // accepted/declined/tentative/needsAction
+};
+
+/**
+ * カレンダーイベント
+ */
+export type CalendarEvent = {
+  /** イベントID */
+  id: string;
+  /** イベント名 */
+  summary: string;
+  /** 説明 */
+  description?: string;
+  /** 開始日時（ISO 8601） */
+  start: string;
+  /** 終了日時（ISO 8601） */
+  end: string;
+  /** 所要時間（分） */
+  durationMinutes: number;
+  /** 参加者 */
+  attendees?: EventAttendee[];
+  /** 主催者メール */
+  organizer?: string;
+  /** ステータス */
+  status: string; // confirmed/tentative/cancelled
+  /** イベント種類 */
+  eventType: EventType;
+  /** Googleカレンダーへのリンク */
+  htmlLink?: string;
+};
+
+/**
+ * 会議統計
+ */
+export type MeetingStats = {
+  /** 総イベント数 */
+  totalEvents: number;
+  /** 総会議時間（分） */
+  totalMeetingMinutes: number;
+  /** 会議数 */
+  meetingCount: number;
+  /** 1on1数 */
+  oneOnOneCount: number;
+  /** 集中時間（分） */
+  focusTimeMinutes: number;
+  /** 平均会議時間（分） */
+  averageMeetingDuration: number;
+  /** 最も忙しい日（YYYY-MM-DD） */
+  busiestDay?: string;
+};

--- a/src/model/slack.ts
+++ b/src/model/slack.ts
@@ -1,0 +1,51 @@
+/**
+ * Slackユーザー情報
+ */
+export type SlackUser = {
+  /** Slack User ID */
+  id: string;
+  /** 表示名 */
+  name: string;
+  /** 本名 */
+  realName?: string;
+  /** メールアドレス */
+  email?: string;
+};
+
+/**
+ * Slackリアクション
+ */
+export type SlackReaction = {
+  /** 絵文字名（例: thumbsup） */
+  name: string;
+  /** リアクション数 */
+  count: number;
+  /** リアクションしたUser IDリスト */
+  users: string[];
+};
+
+/**
+ * Slackメッセージ
+ */
+export type SlackMessage = {
+  /** メッセージID（タイムスタンプ） */
+  id: string;
+  /** メッセージ本文 */
+  text: string;
+  /** 投稿者User ID */
+  user: string;
+  /** チャンネルID */
+  channel: string;
+  /** チャンネル名 */
+  channelName?: string;
+  /** タイムスタンプ */
+  ts: string;
+  /** スレッドのルートタイムスタンプ */
+  threadTs?: string;
+  /** パーマリンク */
+  permalink?: string;
+  /** メッセージタイプ */
+  type: string;
+  /** リアクション一覧 */
+  reactions?: SlackReaction[];
+};

--- a/src/slack/client.ts
+++ b/src/slack/client.ts
@@ -1,37 +1,264 @@
+import { WebClient } from '@slack/web-api';
+import { getConfig } from '../config.js';
+import type { SlackUser, SlackMessage } from '../model/slack.js';
+import type {
+  UsersLookupByEmailResponse,
+  ConversationsHistoryResponse,
+  ConversationsListResponse,
+  ChatGetPermalinkResponse,
+} from './types.js';
+import { convertToSlackMessage, isMessageInPeriod, filterMessages } from './helpers.js';
+
 /**
- * Slackクライアント（プレースホルダー実装）
- * 実際の実装はfeature/11-slack-integrationブランチで追加予定
+ * Slackクライアント
+ * Slack Web APIを使用してメッセージやユーザー情報を取得する
  */
 export class SlackClient {
+  private client: WebClient | null = null;
+  private connected: boolean = false;
+
   /**
    * Slack連携が利用可能かどうかを判定
-   * @returns 現在は常にfalseを返す（未実装）
+   * @returns Bot Tokenが設定されている場合はtrue
    */
   isAvailable(): boolean {
-    return false;
+    const config = getConfig();
+    return !!config.slack.botToken;
   }
 
   /**
-   * メールアドレスからSlackユーザーIDを検索
-   * @param _email メールアドレス
-   * @returns ユーザーID（未実装のため常にnullを返す）
+   * Slack APIに接続する
+   * @throws Error Bot Tokenが設定されていない場合
    */
-  async findUserByEmail(_email: string): Promise<string | null> {
-    return null;
+  async connect(): Promise<void> {
+    if (this.connected) {
+      return;
+    }
+
+    const config = getConfig();
+
+    if (!config.slack.botToken) {
+      throw new Error(
+        'SLACK_BOT_TOKENが設定されていません。\n' +
+        '設定方法: .envファイルにSLACK_BOT_TOKEN=xoxb-...を追加してください。'
+      );
+    }
+
+    this.client = new WebClient(config.slack.botToken);
+    this.connected = true;
+
+    console.log('Slack APIに接続しました');
   }
 
   /**
-   * 指定期間内のメッセージを取得
-   * @param _userId SlackユーザーID
-   * @param _start 開始日時
-   * @param _end 終了日時
-   * @returns メッセージ配列（未実装のため常に空配列を返す）
+   * 接続を切断する
+   */
+  async disconnect(): Promise<void> {
+    this.client = null;
+    this.connected = false;
+  }
+
+  /**
+   * メールアドレスからSlackユーザーを検索
+   * @param email メールアドレス
+   * @returns Slackユーザー情報、見つからない場合はnull
+   */
+  async findUserByEmail(email: string): Promise<SlackUser | null> {
+    if (!this.client) {
+      throw new Error('Slack APIに接続されていません。connect()を先に呼び出してください。');
+    }
+
+    try {
+      const response = (await this.client.users.lookupByEmail({
+        email,
+      })) as UsersLookupByEmailResponse;
+
+      if (!response.ok || !response.user) {
+        console.warn(`Slackユーザーが見つかりません: ${email}`);
+        return null;
+      }
+
+      const user = response.user;
+      return {
+        id: user.id,
+        name: user.name,
+        realName: user.real_name || user.profile?.real_name,
+        email: user.profile?.email,
+      };
+    } catch (error) {
+      console.error(`Slackユーザー検索エラー: ${error}`);
+      return null;
+    }
+  }
+
+  /**
+   * 指定期間内のユーザーのメッセージを取得
+   * @param userId SlackユーザーID
+   * @param start 開始日時
+   * @param end 終了日時
+   * @returns メッセージ配列
    */
   async getMessagesInPeriod(
-    _userId: string,
-    _start: Date,
-    _end: Date
-  ): Promise<any[]> {
-    return [];
+    userId: string,
+    start: Date,
+    end: Date
+  ): Promise<SlackMessage[]> {
+    if (!this.client) {
+      throw new Error('Slack APIに接続されていません。connect()を先に呼び出してください。');
+    }
+
+    const messages: SlackMessage[] = [];
+
+    try {
+      // ユーザーが参加しているチャンネルを取得
+      const channels = await this.getUserChannels();
+
+      // 各チャンネルからメッセージを取得
+      for (const channel of channels) {
+        const channelMessages = await this.getChannelMessages(
+          channel.id,
+          channel.name,
+          userId,
+          start,
+          end
+        );
+        messages.push(...channelMessages);
+      }
+
+      // メッセージをフィルタリング
+      return filterMessages(messages, { excludeThreadReplies: false });
+    } catch (error) {
+      console.error(`Slackメッセージ取得エラー: ${error}`);
+      return [];
+    }
+  }
+
+  /**
+   * ユーザーが参加しているチャンネル一覧を取得
+   * @private
+   */
+  private async getUserChannels(): Promise<Array<{ id: string; name: string }>> {
+    if (!this.client) {
+      throw new Error('Slack APIに接続されていません。');
+    }
+
+    const channels: Array<{ id: string; name: string }> = [];
+    let cursor: string | undefined;
+
+    try {
+      do {
+        const response = (await this.client.conversations.list({
+          types: 'public_channel,private_channel',
+          exclude_archived: true,
+          limit: 100,
+          cursor,
+        })) as ConversationsListResponse;
+
+        if (!response.ok || !response.channels) {
+          break;
+        }
+
+        // 参加しているチャンネルのみを追加
+        for (const channel of response.channels) {
+          if (channel.is_member) {
+            channels.push({
+              id: channel.id,
+              name: channel.name,
+            });
+          }
+        }
+
+        cursor = response.response_metadata?.next_cursor;
+      } while (cursor);
+
+      return channels;
+    } catch (error) {
+      console.error(`チャンネル一覧取得エラー: ${error}`);
+      return [];
+    }
+  }
+
+  /**
+   * 特定のチャンネルから指定ユーザーのメッセージを取得
+   * @private
+   */
+  private async getChannelMessages(
+    channelId: string,
+    channelName: string,
+    userId: string,
+    start: Date,
+    end: Date
+  ): Promise<SlackMessage[]> {
+    if (!this.client) {
+      throw new Error('Slack APIに接続されていません。');
+    }
+
+    const messages: SlackMessage[] = [];
+    let cursor: string | undefined;
+
+    // Unix timestampに変換（秒単位）
+    const oldest = Math.floor(start.getTime() / 1000).toString();
+    const latest = Math.floor(end.getTime() / 1000).toString();
+
+    try {
+      do {
+        const response = (await this.client.conversations.history({
+          channel: channelId,
+          oldest,
+          latest,
+          limit: 100,
+          cursor,
+        })) as ConversationsHistoryResponse;
+
+        if (!response.ok || !response.messages) {
+          break;
+        }
+
+        for (const rawMessage of response.messages) {
+          // 指定ユーザーのメッセージのみを処理
+          if (rawMessage.user !== userId) {
+            continue;
+          }
+
+          // 期間内のメッセージのみを処理
+          if (!isMessageInPeriod(rawMessage.ts, start, end)) {
+            continue;
+          }
+
+          // パーマリンクを取得（オプション）
+          let permalink: string | undefined;
+          try {
+            const permalinkResponse = (await this.client.chat.getPermalink({
+              channel: channelId,
+              message_ts: rawMessage.ts,
+            })) as ChatGetPermalinkResponse;
+
+            if (permalinkResponse.ok) {
+              permalink = permalinkResponse.permalink;
+            }
+          } catch {
+            // パーマリンク取得失敗は無視
+          }
+
+          const message = convertToSlackMessage(
+            rawMessage,
+            channelId,
+            channelName,
+            permalink
+          );
+
+          if (message) {
+            messages.push(message);
+          }
+        }
+
+        cursor = response.response_metadata?.next_cursor;
+      } while (cursor);
+
+      return messages;
+    } catch (error) {
+      console.error(`チャンネル ${channelName} のメッセージ取得エラー: ${error}`);
+      return [];
+    }
   }
 }

--- a/src/slack/helpers.ts
+++ b/src/slack/helpers.ts
@@ -1,0 +1,87 @@
+import type { SlackMessage, SlackReaction } from '../model/slack.js';
+
+/**
+ * Slack APIレスポンスからSlackMessageに変換する
+ */
+export function convertToSlackMessage(
+  rawMessage: {
+    type: string;
+    user?: string;
+    text: string;
+    ts: string;
+    thread_ts?: string;
+    reactions?: Array<{
+      name: string;
+      count: number;
+      users: string[];
+    }>;
+  },
+  channelId: string,
+  channelName?: string,
+  permalink?: string
+): SlackMessage | null {
+  // ユーザーIDがない場合はスキップ（botメッセージなど）
+  if (!rawMessage.user) {
+    return null;
+  }
+
+  // リアクションを変換
+  const reactions: SlackReaction[] | undefined = rawMessage.reactions?.map((r) => ({
+    name: r.name,
+    count: r.count,
+    users: r.users,
+  }));
+
+  return {
+    id: rawMessage.ts,
+    text: rawMessage.text,
+    user: rawMessage.user,
+    channel: channelId,
+    channelName,
+    ts: rawMessage.ts,
+    threadTs: rawMessage.thread_ts,
+    permalink,
+    type: rawMessage.type,
+    reactions,
+  };
+}
+
+/**
+ * メッセージが指定期間内かどうかをチェックする
+ */
+export function isMessageInPeriod(
+  messageTs: string,
+  start: Date,
+  end: Date
+): boolean {
+  const messageTime = parseFloat(messageTs) * 1000; // Unix timestamp to milliseconds
+  const startTime = start.getTime();
+  const endTime = end.getTime();
+
+  return messageTime >= startTime && messageTime <= endTime;
+}
+
+/**
+ * メッセージをフィルタリングする
+ * - Bot投稿を除外
+ * - 空のテキストを除外
+ * - スレッド返信を除外（オプション）
+ */
+export function filterMessages(
+  messages: SlackMessage[],
+  options?: { excludeThreadReplies?: boolean }
+): SlackMessage[] {
+  return messages.filter((msg) => {
+    // 空のテキストを除外
+    if (!msg.text || msg.text.trim() === '') {
+      return false;
+    }
+
+    // スレッド返信を除外する場合
+    if (options?.excludeThreadReplies && msg.threadTs && msg.threadTs !== msg.ts) {
+      return false;
+    }
+
+    return true;
+  });
+}

--- a/src/slack/types.ts
+++ b/src/slack/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Slack Web API レスポンス型定義
+ */
+
+/**
+ * users.lookupByEmail APIレスポンス
+ */
+export type UsersLookupByEmailResponse = {
+  ok: boolean;
+  user?: {
+    id: string;
+    name: string;
+    real_name?: string;
+    profile?: {
+      email?: string;
+      real_name?: string;
+    };
+  };
+  error?: string;
+};
+
+/**
+ * conversations.history APIレスポンス
+ */
+export type ConversationsHistoryResponse = {
+  ok: boolean;
+  messages?: Array<{
+    type: string;
+    user?: string;
+    text: string;
+    ts: string;
+    thread_ts?: string;
+    reactions?: Array<{
+      name: string;
+      count: number;
+      users: string[];
+    }>;
+  }>;
+  has_more?: boolean;
+  response_metadata?: {
+    next_cursor?: string;
+  };
+  error?: string;
+};
+
+/**
+ * conversations.list APIレスポンス
+ */
+export type ConversationsListResponse = {
+  ok: boolean;
+  channels?: Array<{
+    id: string;
+    name: string;
+    is_member: boolean;
+  }>;
+  response_metadata?: {
+    next_cursor?: string;
+  };
+  error?: string;
+};
+
+/**
+ * chat.getPermalink APIレスポンス
+ */
+export type ChatGetPermalinkResponse = {
+  ok: boolean;
+  permalink?: string;
+  error?: string;
+};

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -386,7 +386,12 @@ describe('OneOnOneAgendaAgent', () => {
 
       // Slack mocks
       mockSlackClient.isAvailable.mockReturnValue(true);
-      mockSlackClient.findUserByEmail.mockResolvedValue('U12345');
+      mockSlackClient.findUserByEmail.mockResolvedValue({
+        id: 'U12345',
+        name: 'Taro Sato',
+        realName: '佐藤太郎',
+        email: 'sato@example.com',
+      });
       mockSlackClient.getMessagesInPeriod.mockResolvedValue([
         {
           id: 'msg1',


### PR DESCRIPTION
## 概要

1on1アジェンダ生成ツールに、SlackとGoogle Calendarのデータソースを統合しました。これにより、Backlogの課題・PRに加えて、Slackでのコミュニケーションやカレンダーの予定情報もアジェンダに反映できるようになります。

## 変更内容

### ✅ Slack統合

**実装内容:**
- `SlackClient`の実装（Slack Web API経由）
- メッセージ履歴とリアクションの取得
- メールアドレスからのユーザー検索
- チャンネルごとのメッセージフィルタリング

**新規ファイル:**
- `src/slack/client.ts` - Slackクライアント本体
- `src/slack/types.ts` - Slack API型定義
- `src/slack/helpers.ts` - ヘルパー関数
- `src/model/slack.ts` - Slackドメインモデル

**設定:**
- `SLACK_BOT_TOKEN` - Slack Bot Token（環境変数）

### ✅ Google Calendar統合

**実装内容:**
- `CalendarClient`の実装（Google Calendar API経由）
- イベント情報の取得とOAuth2認証
- 会議統計の計算（総会議時間、1on1数、集中時間など）
- イベント種別の自動判定（meeting, one-on-one, focus-time, other）

**新規ファイル:**
- `src/calendar/client.ts` - Calendarクライアント本体
- `src/calendar/types.ts` - Google Calendar API型定義
- `src/calendar/helpers.ts` - 統計計算とヘルパー関数
- `src/model/calendar.ts` - Calendarドメインモデル

**設定:**
- `GOOGLE_CALENDAR_CREDENTIALS_PATH` - OAuth2認証情報のパス
- `GOOGLE_CALENDAR_TOKEN_PATH` - アクセストークンの保存先

### ✅ AgendaInput拡張

**変更内容:**
- `AgendaInput`型に`slack`と`calendar`フィールドを追加
- ドライランモード(`--dry-run`)でSlack/Calendarデータをプレビュー表示
- `agent.ts`でSlack/Calendarクライアントを統合

**修正ファイル:**
- `src/model/agenda.ts` - AgendaInput型拡張
- `src/agent.ts` - データ収集フロー統合
- `src/config.ts` - calendar設定追加

### ✅ その他の変更

**依存関係:**
- `googleapis` パッケージを追加（Google Calendar API用）

**セキュリティ:**
- `.gitignore`に`token.json`, `credentials.json`を追加（OAuth2トークン保護）

**テスト:**
- Slackテストのモックを修正（SlackUser型対応）
- 既存テスト63件すべて通過

## テスト結果

```
✓ test/file-helpers.test.ts (14 tests)
✓ test/llm/bedrock-client.test.ts (7 tests)
✓ test/llm/agenda-generator.test.ts (6 tests)
✓ test/backlog/client.test.ts (9 tests)
✓ test/batch/config-loader.test.ts (7 tests)
✓ test/batch/batch-generator.test.ts (5 tests)
✓ test/llm/parameter-parser.test.ts (6 tests)
✓ test/agent.test.ts (9 tests)

Test Files  8 passed (8)
Tests  63 passed (63)
```

## セットアップ手順

### Slack設定

1. Slack Appを作成
2. 必要なBot Token Scopesを追加:
   - `users:read`
   - `users:read.email`
   - `channels:history`
   - `groups:history`
   - `im:history`
   - `mpim:history`
3. `.env`に`SLACK_BOT_TOKEN`を設定

### Google Calendar設定

1. Google Cloud Consoleでプロジェクト作成
2. Calendar APIを有効化
3. OAuth2認証情報（デスクトップアプリ）を作成
4. `credentials.json`をダウンロード
5. `.env`に以下を設定:
   - `GOOGLE_CALENDAR_CREDENTIALS_PATH=./credentials.json`
   - `GOOGLE_CALENDAR_TOKEN_PATH=./token.json`

## 動作確認項目

- [x] ビルド成功
- [x] テスト全件通過（63/63）
- [x] TypeScript型チェック通過
- [ ] Slack API実機テスト（要認証情報）
- [ ] Google Calendar API実機テスト（要認証情報）

## 備考

- Slack/Calendar統合はオプショナル（設定なしでも既存機能は動作）
- エラーハンドリング実装済み（データ取得失敗時は警告を出力して継続）
- 既存のBacklogClientパターンを踏襲した一貫性のある設計

🤖 Generated with [Claude Code](https://claude.com/claude-code)